### PR TITLE
add inertia based damping to parallax with control sliders

### DIFF
--- a/LivelyProperties.json
+++ b/LivelyProperties.json
@@ -61,9 +61,33 @@
     "value": 50
   },
   "parallaxIntensity": {
-    "max": 5,
+    "max": 7,
     "min": 0,
     "text": "Parallax",
+    "type": "slider",
+    "value": 1
+  },
+  "parallaxStrength": {
+    "max": 1,
+    "min": 0.20,
+    "step": 0.1,
+    "text": "Mouse Sensitivity",
+    "type": "slider",
+    "value": 1
+  },
+  "parallaxDistance": {
+    "max": 110,
+    "min": 50,
+    "step": 5,
+    "text": "Distance",
+    "type": "slider",
+    "value": 90
+  },
+  "parallaxDamp": {
+    "max": 1,
+    "min": 0.07,
+    "step": 0.1,
+    "text": "Damping",
     "type": "slider",
     "value": 1
   },

--- a/js/script.js
+++ b/js/script.js
@@ -7,7 +7,7 @@ let isPaused = false,
 let devicePixelRatio = window.devicePixelRatio || 1;
 
 let scene, camera, renderer, material;
-let settings = { fps: 30, scale: 1.0, parallaxVal: 1 };
+let settings = { fps: 30, scale: 1.0, parallaxVal: 1, parallaxStrength: 1, parallaxDistance: 90, parallaxDamp: 0.07 };
 let videoElement;
 
 //custom events
@@ -187,6 +187,15 @@ function livelyPropertyListener(name, val) {
     case "parallaxIntensity":
       settings.parallaxVal = val;
       break;
+    case "parallaxStrength":
+      settings.parallaxStrength = val;
+      break;
+    case "parallaxDistance":
+      settings.parallaxDistance = val;
+      break;
+    case "parallaxDamp":
+      settings.parallaxDamp = val;
+      break;
     case "fpsLock":
       settings.fps = val ? 30 : 60;
       break;
@@ -292,15 +301,36 @@ document.getElementById("filePicker").addEventListener("change", function () {
   }
 });
 
-//parallax
-document.addEventListener("mousemove", function (event) {
-  if (settings.parallaxVal == 0) return;
+// parallax
+if (settings.parallaxVal !== 0) {
 
-  const x = (window.innerWidth - event.pageX * settings.parallaxVal) / 90;
-  const y = (window.innerHeight - event.pageY * settings.parallaxVal) / 90;
+  let targetX = 0;
+  let targetY = 0;
+  let currentX = 0;
+  let currentY = 0;
 
-  container.style.transform = `translateX(${x}px) translateY(${y}px) scale(1.09)`;
-});
+  document.addEventListener("mousemove", function (event) {
+    targetX = (window.innerWidth  - event.pageX * settings.parallaxVal * settings.parallaxStrength) / settings.parallaxDistance;
+    targetY = (window.innerHeight - event.pageY * settings.parallaxVal * settings.parallaxStrength) / settings.parallaxDistance;
+  });
+
+  function animateParallax() {
+    const dx = targetX - currentX;
+    const dy = targetY - currentY;
+    const speed = Math.hypot(dx, dy);
+    const damp = Math.min(0.35, settings.parallaxDamp + speed * 0.012);
+
+    currentX += dx * damp;
+    currentY += dy * damp;
+
+    container.style.transform =
+      `translateX(${currentX}px) translateY(${currentY}px) scale(1.06)`;
+
+    requestAnimationFrame(animateParallax);
+  }
+
+  animateParallax();
+}
 
 //helpers
 function getExtension(filePath) {


### PR DESCRIPTION
Add inertia and damping effect to the parallax to provide an option to reduce in the jerkiness with fast mouse movements. Three new control sliders in addition to the existing parallax slider control:

1. Mouse Sensitivity - modulates the parallax influence by the mouse
2. Distance - controls the movement range
3. Damping - controls how pronounced the damping is

Default values are based to start at the original feel and the range of the main parallax effect has been increased a bit due to the new calculation.
